### PR TITLE
Add extra step in `Generating ISO Image` / add `rm -rf iso` in `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,5 +53,4 @@ install: primus-os.bin
 	sudo cp $< /boot/primus-os.bin
 
 clean:
-	rm -f *.o primus-os primus-os.iso primus-os.bin $(OBJ_DIR)/*.o
-	rm -rf iso
+	rm -f *.o primus-os primus-os.iso primus-os.bin $(OBJ_DIR)/*.o iso

--- a/Makefile
+++ b/Makefile
@@ -53,4 +53,4 @@ install: primus-os.bin
 	sudo cp $< /boot/primus-os.bin
 
 clean:
-	rm -f *.o primus-os primus-os.iso primus-os.bin $(OBJ_DIR)/*.o iso
+	rm -rf *.o primus-os primus-os.iso primus-os.bin $(OBJ_DIR)/*.o iso

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ LDPARAMS = -melf_i386
 SRC_DIR=src
 HDR_DIR=include/
 OBJ_DIR=obj
+ISO_DIR=iso
 
 SRC_FILES1=$(wildcard $(SRC_DIR)/*.c)
 OBJ_FILES1=$(patsubst $(SRC_DIR)/%.c, $(OBJ_DIR)/%.o, $(SRC_FILES1))
@@ -53,3 +54,4 @@ install: primus-os.bin
 
 clean:
 	rm -f *.o primus-os primus-os.iso primus-os.bin $(OBJ_DIR)/*.o
+	rm -rf iso

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Inspired by Terry A. Davis (in memoriam).
 
 ## Generating the ISO image
 
+`make check_dir`
 `make clean` <br>
 `make primus-os.iso`
 


### PR DESCRIPTION
Followed the `README.md` but found that the first step required when generating an ISO image should be `make check_dir`. Added this for future users.

This missing step led to the iso folder being generated but not removed as expected. went and added the removal of the iso folder as part of make clean in the case that the iso for some reason does not get removed